### PR TITLE
Remove redundant media query in section 9.

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -9,7 +9,7 @@
 
 /* 9. CUSTOM LAYOUT & TYPOGRAPHY (Mummy bear)
 ----------------------------------------------------------------------------------------*/
-@media screen and (min-width: 30em) and (max-width: 63.236em) {
+@media screen and (max-width: 63.236em) {
 
 #container { width: 30em; }
 	


### PR DESCRIPTION
Section 9, Mummy Bear, had a check for the minimum width of 30em even
though that stylesheet doesn't load (index.html#23) on devices less than
33.236em.

Removed that query in layout.css, fixing the redundancy and saving tens
of CPU cycles.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/designbyfront/the-goldilocks-approach/9)

<!-- Reviewable:end -->
